### PR TITLE
Use get_orders in um_futures examples

### DIFF
--- a/examples/um_futures/trade/get_open_orders.py
+++ b/examples/um_futures/trade/get_open_orders.py
@@ -12,9 +12,7 @@ secret = ""
 um_futures_client = UMFutures(key=key, secret=secret)
 
 try:
-    response = um_futures_client.get_open_orders(
-        symbol="BTCUSDT", orderId=35298599362, recvWindow=2000
-    )
+    response = um_futures_client.get_orders(symbol="BTCUSDT", recvWindow=2000)
     logging.info(response)
 except ClientError as error:
     logging.error(


### PR DESCRIPTION
The example was making a call to the endpoint that is used to get a specific order, so I replaced it with the one that is used to get all open orders for a symbol.