### PR TITLE
call on_error on WebSocketException instead of raising the exception

### DIFF
--- a/binance/websocket/binance_socket_manager.py
+++ b/binance/websocket/binance_socket_manager.py
@@ -71,7 +71,7 @@ class BinanceSocketManager(threading.Thread):
                     self.logger.error("Lost websocket connection")
                 else:
                     self.logger.error("Websocket exception: {}".format(e))
-                raise e
+                self._callback(self.on_error, e)
             except Exception as e:
                 self.logger.error("Exception in read_data: {}".format(e))
                 raise e


### PR DESCRIPTION
Currently, when we have a WebSocketException, there is no way to handle it as the raised exception is contained inside the runner thread. This PR will call the on_error callback instead to allow handling it.